### PR TITLE
Remove lint for labels on resource references.

### DIFF
--- a/internal/docs/config.go
+++ b/internal/docs/config.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-
-	"github.com/Jeffail/gabs/v2"
 )
 
 const labelExpression = `^[a-z0-9_]+$`
@@ -31,16 +29,7 @@ func ValidateLabel(label string) error {
 
 var labelField = FieldString(
 	"label", "An optional label to use as an identifier for observability data such as metrics and logging.",
-).OmitWhen(func(field, parent any) (string, bool) {
-	gObj := gabs.Wrap(parent)
-	if typeStr, exists := gObj.S("type").Data().(string); exists && typeStr == "resource" {
-		return "label field should be omitted when pointing to a resource", true
-	}
-	if resourceStr, exists := gObj.S("resource").Data().(string); exists && resourceStr != "" {
-		return "label field should be omitted when pointing to a resource", true
-	}
-	return "", false
-}).AtVersion("3.44.0").LinterFunc(func(ctx LintContext, line, col int, v any) []Lint {
+).AtVersion("3.44.0").LinterFunc(func(ctx LintContext, line, col int, v any) []Lint {
 	l, _ := v.(string)
 	if l == "" {
 		return nil


### PR DESCRIPTION
On met des labels sur nos références à des ressources parce qu'on veut éviter de mettre des json pointers dans les tests parce que c'est brittle.

`FieldString` est un genre de builder et le field populé par `OmitWhen` est null-safe (https://github.com/withnocode/benthos/blob/main/internal/docs/yaml.go#L155)

Tous les tests passent encore, sauf un qui était déjà brisé.